### PR TITLE
- grab tags when fetching

### DIFF
--- a/modules/git.sh
+++ b/modules/git.sh
@@ -9,7 +9,7 @@ git_check() {
 	declare OldRev NewRev
 
 	OldRev=$(git_describe) &&
-	git fetch origin "$Branch" &&
+	git fetch origin "$Branch" --tags &&
 	git reset --hard "origin/$Branch" &&
 	NewRev=$(git_describe) || return
 


### PR DESCRIPTION
The dev builds are appearing with the old 3.8pre tags when they should be showing with the 4.1pre tags. This is meant to fix that.