### PR TITLE
Recurse submodules in git_check

### DIFF
--- a/modules/git.sh
+++ b/modules/git.sh
@@ -9,7 +9,7 @@ git_check() {
 	declare OldRev NewRev
 
 	OldRev=$(git_describe) &&
-	git fetch origin "$Branch" --tags &&
+	git fetch origin "$Branch" --recurse-submodules --tags &&
 	git reset --hard "origin/$Branch" &&
 	NewRev=$(git_describe) || return
 


### PR DESCRIPTION
I think this is necessary and fixes the issues that meant no EE builds were updating after the opl3-branch merge.