### PR TITLE
Use VS2017 and XP toolset for Eternity Engine

### DIFF
--- a/win/eternity.sh
+++ b/win/eternity.sh
@@ -22,8 +22,8 @@ eternity_configure() {
 		;;
 	x86)
 		CMakeArgs+=(
-			'-GVisual Studio 16 2019'
-			'-AWin32'
+			'-GVisual Studio 15 2017'
+			'-Tv141_xp'
 		)
 		;;
 	esac


### PR DESCRIPTION
I just fixed v141_xp support for EE, which I accidentally broke. Some end-users still use Windows XP, and in addition Win32 builds currently have janked out slopes for VS2019 for whatever reason, so using VS2017 and v141_xp is currently desireable.