### PR TITLE
Add AUTHORS to the Eternity packages

### DIFF
--- a/mac/eternity.sh
+++ b/mac/eternity.sh
@@ -20,7 +20,7 @@ eternity_configure() {
 eternity_package() {
 	#declare -n Config=$1
 	shift
-	#declare ProjectDir=$1
+	declare ProjectDir=$1
 	shift
 	declare Version=$1
 	shift
@@ -28,7 +28,7 @@ eternity_package() {
 	shift
 
 	sign_app "x86_64/macosx/launcher/Release/Eternity Engine.app" &&
-	make_dmg 'Eternity Engine' "eternity-$Version.dmg" "x86_64/macosx/launcher/Release/Eternity Engine.app" || return
+	make_dmg 'Eternity Engine' "eternity-$Version.dmg" "x86_64/macosx/launcher/Release/Eternity Engine.app" "$ProjectDir/AUTHORS" || return
 
 	Artifacts+=("eternity-$Version.dmg")
 }

--- a/win/eternity.sh
+++ b/win/eternity.sh
@@ -50,6 +50,7 @@ eternity_package() {
 				"$(pwd)"/eternity/Release/*.* \
 				"$ProjectDir/user" \
 				"$ProjectDir/base" \
+				"$ProjectDir/AUTHORS" \
 				-mx=9 '-xr!.gitignore' '-xr!delete.me' '-x!*.map' &&
 			7z a "../Eternity-$Arch-$Version.map.xz" "$(pwd)/eternity/Release/eternity.map" -mx=9 &&
 			7z a "../Eternity-$Arch-$Version.pdb.xz" "$(pwd)/eternity/Release/eternity.pdb" -mx=9


### PR DESCRIPTION
I've made this pull request to add the AUTHORS files to the development builds. This is necessary to credit the contributors, especially later when I add third-party library license info _as required in their terms_ (we should have done that from the start on our project, but this is a first step).